### PR TITLE
Don't duplicate headers

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,3 +22,5 @@ make install
 
 cd $PREFIX
 rm -rf share/doc
+rm include/wcslib # this is a symlink
+mv include/wcslib-* include/wcslib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - no-x-tests.patch # avoid deluges of pgplot warnings
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 


### PR DESCRIPTION
wcslib installs its headers in `$PREFIX/include/wcslib-$MAJOR.$MINOR` and then
symlinks `$PREFIX/include/wcslib` to point at this directory. Conda doesn't
handle symlinks specially when packaging, so this ends up creating two copies
of the headers. In this commit we ditch the symlink and just install to
`$PREFIX/include/wcslib` unconditionally. The wcslib pkg-config file lists
this as the include directory and it's just easier for everyone to deal with,
instead of changing the directory for every minor version increment.