### PR TITLE
Updating to version 5.17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "wcslib" %}
-{% set version = "5.16" %}
-{% set sha256 = "ed031e0cf1cec0e9cabfc650423efa526fec341441865001c1e2c56bfffc99ef" %}
+{% set version = "5.17" %}
+{% set sha256 = "5c9cb5c86be01703f6488774ef3ea44fd6918a4dcdfddc70855905c05de8436c" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.bz2
-  url: http://newton.cx/~peter/files/{{ name }}-{{ version }}.tar.bz2
+  url: ftp://ftp.atnf.csiro.au/pub/software/wcslib/{{ name }}-{{ version }}.tar.bz2
   sha256: {{ sha256 }}
   patches:
     - no-x-tests.patch # avoid deluges of pgplot warnings


### PR DESCRIPTION
As agreed in #4 , here is a pull request to update to version 5.17 (and use the "official" download link as provided on the heasarc website).