### PR TITLE
Gotta stick with pgplot -- giza missing functionality used by casa-tools

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,7 @@ configure_args=(
     --with-cfitsiolib=$PREFIX/lib
     --with-cfitsioinc=$PREFIX/include
     --with-pgplotlib=$PREFIX/lib
-    --with-pgplotinc=$PREFIX/include
+    --with-pgplotinc=$PREFIX/include/pgplot
 )
 
 ./configure "${configure_args[@]}" || { cat config.log ; exit 1 ; }

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - no-x-tests.patch # avoid deluges of pgplot warnings
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 
@@ -23,13 +23,13 @@ requirements:
     - cfitsio
     - flex
     - gcc  # [osx]
-    - giza 0.9.*  # [not win]
     - libgfortran  # [linux]
+    - pgplot 5.2.*  # [not win]
     - toolchain
   run:
     - cfitsio
-    - giza 0.9.*  # [not win]
     - libgfortran  # [not win]
+    - pgplot 5.2.*  # [not win]
 
 test:
   commands:


### PR DESCRIPTION
This effectively reverts commits df361d1bdafff0c34a0ca1aa3778d50b50f106eb and
0f1aedabd0442eaf2f7dfc01d67763d4f9bf72fc.